### PR TITLE
'getHtmlContent()' -> 'getHtml()'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![](https://jitpack.io/v/RahulSDeshpande/KRichEditor.svg)](https://jitpack.io/#RahulSDeshpande/KRichEditor)
 [![API](https://img.shields.io/badge/API-17%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=17)
 [ ![Download](https://api.bintray.com/packages/ebolo/ebolo-oss/krichtexteditor/images/download.svg)](https://bintray.com/ebolo/ebolo-oss/krichtexteditor/_latestVersion)
 [![](https://jitpack.io/v/daothanhduy305/KRichEditor.svg)](https://jitpack.io/#daothanhduy305/KRichEditor)

--- a/krichtexteditor/src/main/java/com/ebolo/krichtexteditor/RichEditor.kt
+++ b/krichtexteditor/src/main/java/com/ebolo/krichtexteditor/RichEditor.kt
@@ -464,7 +464,9 @@ class RichEditor {
      *
      * @param callBack ValueCallback<String> action to do
      */
-    private fun getHtmlContent(callBack: ValueCallback<String>) = load("javascript:getHtmlContent()", callBack)
+    // Correcting javascript method name from `getHtmlContent()' to 'getHtml()'
+    // private fun getHtmlContent(callBack: ValueCallback<String>) = load("javascript:getHtmlContent()", callBack)
+    private fun getHtmlContent(callBack: ValueCallback<String>) = load("javascript:getHtml()", callBack)
 
     /**
      * Method to get the HTML content and do (any) actions on the result


### PR DESCRIPTION
- Correcting javascript method name from `getHtmlContent()' to 'getHtml()'